### PR TITLE
Update to `syn` v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "derive-syn-parse"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["sharnoff <github@max.sharnoff.org>"]
 license = "MIT OR Apache-2.0"
 description = "Derive macro for `syn::parse::Parse`"
 repository = "https://github.com/sharnoff/derive-syn-parse"
 categories = ["development-tools::procedural-macro-helpers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", features = ["derive", "parsing"] }
+syn = { version = "2", features = ["derive", "parsing"] }
 quote = "1"
 proc-macro2 = "1"
 
 # Testing relies on being able to compare the output of the macros, which is why we need a
 # different version of syn
 [dev-dependencies]
-syn = { version = "1", features = ["full", "extra-traits"] }
+syn = { version = "2", features = ["full", "extra-traits"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "Derive macro for `syn::parse::Parse`"
 repository = "https://github.com/sharnoff/derive-syn-parse"
 categories = ["development-tools::procedural-macro-helpers"]
-edition = "2021"
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -5,7 +5,7 @@ use quote::{format_ident, quote, quote_spanned, ToTokens};
 use std::convert::{TryFrom, TryInto};
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{parenthesized, AttrStyle, Attribute, Expr, Fields, Ident, Path, Result, Token, Type};
+use syn::{AttrStyle, Attribute, Expr, Fields, Ident, Path, Result, Token, Type};
 
 pub(crate) fn generate_fn_body(
     base_tyname: &impl ToTokens,
@@ -189,15 +189,15 @@ fn parse_field((idx, field): (usize, syn::Field)) -> Result<TokenStream> {
 }
 
 fn try_as_field_attr(attr: Attribute) -> Option<Result<(FieldAttr, Span)>> {
-    let name = attr.path.get_ident()?.to_string();
+    let name = attr.path().get_ident()?.to_string();
     let span = attr.span();
 
     macro_rules! expect_outer_attr {
-        () => {{
+        ($name:literal) => {{
             if let AttrStyle::Inner(_) = attr.style {
                 return Some(Err(syn::Error::new(
                     span,
-                    "this parsing attribute can only be used as an outer attribute",
+                    concat!("the `#[", $name, "]` parsing attribute can only be used as an outer attribute"),
                 )));
             }
         }};
@@ -206,101 +206,119 @@ fn try_as_field_attr(attr: Attribute) -> Option<Result<(FieldAttr, Span)>> {
     #[rustfmt::skip]
     macro_rules! expect_no_attr_args {
         ($name:expr) => {{
-            if !attr.tokens.is_empty() {
-                return Some(Err(syn::Error::new(
+            use syn::Meta::*;
+            match attr.meta {
+                List(args)      =>  return Some(Err(syn::Error::new(
                     span,
-                    concat!("the ", $name, " parsing attribute does not expect any arguments"),
-                )));
+                    format!("the `#[{}]` parsing attribute does not expect arguments {:?}", $name, args.tokens.to_string()),
+                ))),
+                NameValue(val)  =>  return Some(Err(syn::Error::new(
+                    span,
+                    format!("the `#[{}]` parsing attribute does not expect value {:?}", $name, val.value.to_token_stream().to_string()),
+                ))),
+                _               =>  {}
             }
         }};
     }
 
-    struct Inside<T: Parse> {
-        _paren_token: syn::token::Paren,
-        inner: T,
+    macro_rules! expect_parenthesis {
+        ($attr_lit:literal) => {{
+            use syn::{Meta, MacroDelimiter::*};
+            match attr.meta {
+                Meta::List(ref ml)  =>  match ml.delimiter {
+                    Paren(_)    =>  {},
+                    Brace(_)    =>  return Some(Err(syn::Error::new(
+                        span,
+                        concat!("expected parenthesis in `#[", $attr_lit, "(...)]`, found braces")
+                    ))),
+                    Bracket(_)    =>  return Some(Err(syn::Error::new(
+                        span,
+                        concat!("expected parenthesis in `#[", $attr_lit, "(...)]`, found brackets")
+                    ))),
+                },
+                _   => return Some(Err(syn::Error::new(
+                    span,
+                    concat!("expected parenthesis in `#[", $attr_lit, "(...)]`")
+                )))
+            }
+        }};
     }
-
-    impl<T: Parse> Parse for Inside<T> {
-        fn parse(input: ParseStream) -> Result<Self> {
-            let paren;
-            Ok(Inside {
-                _paren_token: parenthesized!(paren in input),
-                inner: paren.parse()?,
-            })
-        }
-    }
-
     match name.as_str() {
         "inside" => {
-            expect_outer_attr!();
-            Some(
-                syn::parse2(attr.tokens)
-                    .map(move |id: Inside<_>| (FieldAttr::Inside(id.inner), span)),
-            )
+            expect_outer_attr!("inside(...)");
+            expect_parenthesis!("inside");
+            Some(attr.parse_args().map(move |id| (FieldAttr::Inside(id), span)))
         }
         "call" => {
-            expect_outer_attr!();
+            expect_outer_attr!("call(...)");
+            expect_parenthesis!("call");
             Some(
-                syn::parse2(attr.tokens)
-                    .map(move |id: Inside<_>| (FieldAttr::Call(id.inner), span)),
+                attr.parse_args()
+                    .map(move |id| (FieldAttr::Call(id), span)),
             )
         }
         "parse_terminated" => {
-            expect_outer_attr!();
+            expect_outer_attr!("parse_terminated(...)");
+            expect_parenthesis!("parse_terminated");
             Some(
-                syn::parse2(attr.tokens)
-                    .map(move |id: Inside<_>| (FieldAttr::ParseTerminated(id.inner), span)),
+                attr.parse_args()
+                    .map(move |id| (FieldAttr::ParseTerminated(id), span)),
             )
         }
         "paren" => {
-            expect_outer_attr!();
-            expect_no_attr_args!("`#[paren]`");
+            expect_outer_attr!("paren");
+            expect_no_attr_args!("paren");
             Some(Ok((FieldAttr::Tree(TreeKind::Paren), span)))
         }
         "bracket" => {
-            expect_outer_attr!();
-            expect_no_attr_args!("`#[bracket]`");
+            expect_outer_attr!("bracket");
+            expect_no_attr_args!("bracket");
             Some(Ok((FieldAttr::Tree(TreeKind::Bracket), span)))
         }
         "brace" => {
-            expect_outer_attr!();
-            expect_no_attr_args!("`#[brace]`");
+            expect_outer_attr!("brace");
+            expect_no_attr_args!("brace");
             Some(Ok((FieldAttr::Tree(TreeKind::Brace), span)))
         }
         "peek" => {
-            expect_outer_attr!();
+            expect_outer_attr!("peek(...)");
+            expect_parenthesis!("peek");
             Some(
-                syn::parse2(attr.tokens)
-                    .map(move |id: Inside<_>| (FieldAttr::Peek(PeekAttr::Peek(id.inner)), span)),
+                attr.parse_args()
+                    .map(move |id| (FieldAttr::Peek(PeekAttr::Peek(id)), span)),
             )
         }
         "peek_with" => {
-            expect_outer_attr!();
+            expect_outer_attr!("peek_with(...)");
+            expect_parenthesis!("peek_with");
             Some(
-                syn::parse2(attr.tokens).map(move |id: Inside<_>| {
-                    (FieldAttr::Peek(PeekAttr::PeekWith(id.inner)), span)
+                attr.parse_args().map(move |id| {
+                    (FieldAttr::Peek(PeekAttr::PeekWith(id)), span)
                 }),
             )
         }
         "parse_if" => {
-            expect_outer_attr!();
+            expect_outer_attr!("parse_if(...)");
+            expect_parenthesis!("parse_if");
             Some(
-                syn::parse2(attr.tokens)
-                    .map(move |id: Inside<_>| (FieldAttr::Peek(PeekAttr::ParseIf(id.inner)), span)),
+                attr.parse_args()
+                    .map(move |id| (FieldAttr::Peek(PeekAttr::ParseIf(id)), span)),
             )
         }
         "prefix" => {
-            expect_outer_attr!();
+            expect_outer_attr!("prefix(...)");
+            expect_parenthesis!("prefix");
             Some(
-                syn::parse2(attr.tokens)
-                    .map(move |id: Inside<_>| (FieldAttr::Prefix(id.inner), span)),
+                attr.parse_args()
+                    .map(move |id| (FieldAttr::Prefix(id), span)),
             )
         }
         "postfix" => {
-            expect_outer_attr!();
+            expect_outer_attr!("postifx(...)");
+            expect_parenthesis!("postfix");
             Some(
-                syn::parse2(attr.tokens)
-                    .map(move |id: Inside<_>| (FieldAttr::Postfix(id.inner), span)),
+                attr.parse_args()
+                    .map(move |id| (FieldAttr::Postfix(id), span)),
             )
         }
         _ => None,

--- a/src/fields.rs
+++ b/src/fields.rs
@@ -197,7 +197,11 @@ fn try_as_field_attr(attr: Attribute) -> Option<Result<(FieldAttr, Span)>> {
             if let AttrStyle::Inner(_) = attr.style {
                 return Some(Err(syn::Error::new(
                     span,
-                    concat!("the `#[", $name, "]` parsing attribute can only be used as an outer attribute"),
+                    concat!(
+                        "the `#[",
+                        $name,
+                        "]` parsing attribute can only be used as an outer attribute"
+                    ),
                 )));
             }
         }};
@@ -223,23 +227,37 @@ fn try_as_field_attr(attr: Attribute) -> Option<Result<(FieldAttr, Span)>> {
 
     macro_rules! expect_parenthesis {
         ($attr_lit:literal) => {{
-            use syn::{Meta, MacroDelimiter::*};
+            use syn::{MacroDelimiter::*, Meta};
             match attr.meta {
-                Meta::List(ref ml)  =>  match ml.delimiter {
-                    Paren(_)    =>  {},
-                    Brace(_)    =>  return Some(Err(syn::Error::new(
-                        span,
-                        concat!("expected parenthesis in `#[", $attr_lit, "(...)]`, found braces")
-                    ))),
-                    Bracket(_)    =>  return Some(Err(syn::Error::new(
-                        span,
-                        concat!("expected parenthesis in `#[", $attr_lit, "(...)]`, found brackets")
-                    ))),
+                Meta::List(ref ml) => match ml.delimiter {
+                    Paren(_) => {}
+                    Brace(_) => {
+                        return Some(Err(syn::Error::new(
+                            span,
+                            concat!(
+                                "expected parenthesis in `#[",
+                                $attr_lit,
+                                "(...)]`, found braces"
+                            ),
+                        )))
+                    }
+                    Bracket(_) => {
+                        return Some(Err(syn::Error::new(
+                            span,
+                            concat!(
+                                "expected parenthesis in `#[",
+                                $attr_lit,
+                                "(...)]`, found brackets"
+                            ),
+                        )))
+                    }
                 },
-                _   => return Some(Err(syn::Error::new(
-                    span,
-                    concat!("expected parenthesis in `#[", $attr_lit, "(...)]`")
-                )))
+                _ => {
+                    return Some(Err(syn::Error::new(
+                        span,
+                        concat!("expected parenthesis in `#[", $attr_lit, "(...)]`"),
+                    )))
+                }
             }
         }};
     }
@@ -247,15 +265,15 @@ fn try_as_field_attr(attr: Attribute) -> Option<Result<(FieldAttr, Span)>> {
         "inside" => {
             expect_outer_attr!("inside(...)");
             expect_parenthesis!("inside");
-            Some(attr.parse_args().map(move |id| (FieldAttr::Inside(id), span)))
+            Some(
+                attr.parse_args()
+                    .map(move |id| (FieldAttr::Inside(id), span)),
+            )
         }
         "call" => {
             expect_outer_attr!("call(...)");
             expect_parenthesis!("call");
-            Some(
-                attr.parse_args()
-                    .map(move |id| (FieldAttr::Call(id), span)),
-            )
+            Some(attr.parse_args().map(move |id| (FieldAttr::Call(id), span)))
         }
         "parse_terminated" => {
             expect_outer_attr!("parse_terminated(...)");
@@ -292,9 +310,8 @@ fn try_as_field_attr(attr: Attribute) -> Option<Result<(FieldAttr, Span)>> {
             expect_outer_attr!("peek_with(...)");
             expect_parenthesis!("peek_with");
             Some(
-                attr.parse_args().map(move |id| {
-                    (FieldAttr::Peek(PeekAttr::PeekWith(id)), span)
-                }),
+                attr.parse_args()
+                    .map(move |id| (FieldAttr::Peek(PeekAttr::PeekWith(id)), span)),
             )
         }
         "parse_if" => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,11 +1,6 @@
 use quote::ToTokens;
 use syn::{parse2, parse_str, DeriveInput, ItemImpl};
 
-#[test]
-fn interim() {
-    nested_attrs();
-}
-
 macro_rules! test_all {
     (
         $(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,11 @@
 use quote::ToTokens;
 use syn::{parse2, parse_str, DeriveInput, ItemImpl};
 
+#[test]
+fn interim() {
+    nested_attrs();
+}
+
 macro_rules! test_all {
     (
         $(

--- a/src/variants.rs
+++ b/src/variants.rs
@@ -2,7 +2,7 @@
 
 use crate::fields::generate_fn_body;
 use proc_macro2::{Span, TokenStream};
-use quote::{ToTokens, quote, quote_spanned};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::token;

--- a/src/variants.rs
+++ b/src/variants.rs
@@ -2,7 +2,7 @@
 
 use crate::fields::generate_fn_body;
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, quote_spanned};
+use quote::{ToTokens, quote, quote_spanned};
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::token;
@@ -151,11 +151,11 @@ fn extract_single_attr(variant_span: Span, attrs: Vec<Attribute>) -> Result<Vari
 }
 
 fn try_as_variant_attr(attr: Attribute) -> Option<Result<VariantAttr>> {
-    let name = attr.path.get_ident()?.to_string();
+    let name = attr.path().get_ident()?.to_string();
 
     match name.as_str() {
-        "peek" => Some(syn::parse2(attr.tokens).map(VariantAttr::Peek)),
-        "peek_with" => Some(syn::parse2(attr.tokens).map(VariantAttr::PeekWith)),
+        "peek" => Some(syn::parse2(attr.into_token_stream()).map(VariantAttr::Peek)),
+        "peek_with" => Some(syn::parse2(attr.into_token_stream()).map(VariantAttr::PeekWith)),
         _ => None,
     }
 }

--- a/src/variants.rs
+++ b/src/variants.rs
@@ -2,11 +2,10 @@
 
 use crate::fields::generate_fn_body;
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, quote_spanned, ToTokens};
+use quote::{quote, quote_spanned};
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::token;
-use syn::{parenthesized, Attribute, Expr, Ident, LitStr, Result, Token, Variant};
+use syn::{Attribute, Expr, Ident, LitStr, Result, Token, Variant};
 
 pub(crate) fn generate_impl(
     variants: impl ExactSizeIterator<Item = Variant>,
@@ -79,7 +78,6 @@ mod kwd {
 }
 
 struct PeekInfo {
-    _paren_token: token::Paren,
     expr: Expr,
     _comma: Token![,],
     _name_token: kwd::name,
@@ -154,8 +152,8 @@ fn try_as_variant_attr(attr: Attribute) -> Option<Result<VariantAttr>> {
     let name = attr.path().get_ident()?.to_string();
 
     match name.as_str() {
-        "peek" => Some(syn::parse2(attr.into_token_stream()).map(VariantAttr::Peek)),
-        "peek_with" => Some(syn::parse2(attr.into_token_stream()).map(VariantAttr::PeekWith)),
+        "peek" => Some(attr.parse_args().map(VariantAttr::Peek)),
+        "peek_with" => Some(attr.parse_args().map(VariantAttr::PeekWith)),
         _ => None,
     }
 }
@@ -166,14 +164,12 @@ fn try_as_variant_attr(attr: Attribute) -> Option<Result<VariantAttr>> {
 
 impl Parse for PeekInfo {
     fn parse(input: ParseStream) -> Result<Self> {
-        let paren;
         Ok(PeekInfo {
-            _paren_token: parenthesized!(paren in input),
-            expr: paren.parse()?,
-            _comma: paren.parse()?,
-            _name_token: paren.parse()?,
-            _eq: paren.parse()?,
-            name: paren.parse()?,
+            expr: input.parse()?,
+            _comma: input.parse()?,
+            _name_token: input.parse()?,
+            _eq: input.parse()?,
+            name: input.parse()?,
         })
     }
 }


### PR DESCRIPTION
Updated `syn` to v2.  Documentation hasn't been touched, however.  Also bumped `Cargo.toml` version to `0.2`.